### PR TITLE
Generate models

### DIFF
--- a/app/models/deployment.rb
+++ b/app/models/deployment.rb
@@ -1,0 +1,3 @@
+class Deployment < ActiveRecord::Base
+  belongs_to :service
+end

--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -1,0 +1,3 @@
+class Endpoint < ActiveRecord::Base
+  belongs_to :instance
+end

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -1,3 +1,4 @@
 class Instance < ActiveRecord::Base
   belongs_to :service
+  has_many :endpoint
 end

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -1,0 +1,3 @@
+class Instance < ActiveRecord::Base
+  belongs_to :service
+end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -1,0 +1,3 @@
+class Repository < ActiveRecord::Base
+  belongs_to :service
+end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,0 +1,2 @@
+class Service < ActiveRecord::Base
+end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,2 +1,5 @@
 class Service < ActiveRecord::Base
+  has_many :repository
+  has_many :deployment
+  has_many :instance
 end

--- a/db/migrate/20140531195423_create_services.rb
+++ b/db/migrate/20140531195423_create_services.rb
@@ -1,0 +1,12 @@
+class CreateServices < ActiveRecord::Migration
+  def change
+    create_table :services do |t|
+      t.string :name
+      t.string :group
+      t.string :jira
+      t.string :confluence
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20140531195509_create_repositories.rb
+++ b/db/migrate/20140531195509_create_repositories.rb
@@ -1,0 +1,11 @@
+class CreateRepositories < ActiveRecord::Migration
+  def change
+    create_table :repositories do |t|
+      t.string :description
+      t.string :url
+      t.belongs_to :service, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20140531195728_create_deployments.rb
+++ b/db/migrate/20140531195728_create_deployments.rb
@@ -1,0 +1,12 @@
+class CreateDeployments < ActiveRecord::Migration
+  def change
+    create_table :deployments do |t|
+      t.string :name
+      t.string :description
+      t.string :url
+      t.belongs_to :service, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20140531200013_create_instances.rb
+++ b/db/migrate/20140531200013_create_instances.rb
@@ -1,0 +1,12 @@
+class CreateInstances < ActiveRecord::Migration
+  def change
+    create_table :instances do |t|
+      t.string :name
+      t.string :version_of_artifact
+      t.string :description
+      t.belongs_to :service, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20140531200305_create_endpoints.rb
+++ b/db/migrate/20140531200305_create_endpoints.rb
@@ -1,0 +1,13 @@
+class CreateEndpoints < ActiveRecord::Migration
+  def change
+    create_table :endpoints do |t|
+      t.string :name
+      t.string :description
+      t.string :endpoint_type
+      t.string :url
+      t.belongs_to :instance, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,69 @@
+# encoding: UTF-8
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20140531200305) do
+
+  create_table "deployments", force: true do |t|
+    t.string   "name"
+    t.string   "description"
+    t.string   "url"
+    t.integer  "service_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "deployments", ["service_id"], name: "index_deployments_on_service_id"
+
+  create_table "endpoints", force: true do |t|
+    t.string   "name"
+    t.string   "description"
+    t.string   "endpoint_type"
+    t.string   "url"
+    t.integer  "instance_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "endpoints", ["instance_id"], name: "index_endpoints_on_instance_id"
+
+  create_table "instances", force: true do |t|
+    t.string   "name"
+    t.string   "version_of_artifact"
+    t.string   "description"
+    t.integer  "service_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "instances", ["service_id"], name: "index_instances_on_service_id"
+
+  create_table "repositories", force: true do |t|
+    t.string   "description"
+    t.string   "url"
+    t.integer  "service_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "repositories", ["service_id"], name: "index_repositories_on_service_id"
+
+  create_table "services", force: true do |t|
+    t.string   "name"
+    t.string   "group"
+    t.string   "jira"
+    t.string   "confluence"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,58 @@
 #
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
+
+# Helper to create CV instances
+def create_instance(version:, version_of_artifact:, direct_url:, mediation_url:)
+  cv_instance = Instance.new(name: "Commuted Value Service #{version}",
+  version_of_artifact: version_of_artifact)
+  cv_instance.endpoint << Endpoint.create(
+    name: "commutedValueService#{version}",
+    description: "Direct endpoint to version #{version}",
+    endpoint_type: 'Direct',
+    url: direct_url)
+  cv_instance.endpoint << Endpoint.create(
+    name: "Development.WESB.commutedValueService#{version}",
+    description: "WESB mediation to version #{version}",
+    endpoint_type: 'WESB mediation',
+    url: mediation_url)
+  cv_instance
+end
+
+# Create the CV web service
+cv_service = Service.new(name: 'Commuted Value Web Service',
+  group: 'Core Service',
+  jira: 'http://jira',
+  confluence: 'http://confluence/display/SYS/Commuted+Value+Web-Service')
+
+cv_service.repository << Repository.create(
+  url: 'http://src/benefits/com.otpp.domain.commutedvalue')
+cv_service.repository << Repository.create(
+  url: 'http://src/benefits/com.otpp.ws.commutedValue')
+cv_service.repository << Repository.create(
+  url: 'http://src/benefits/benefit-dev-props')
+cv_service.repository << Repository.create(
+  url: 'http://src/middleware/commutedvalue-prod-properties')
+
+cv_service.deployment << Deployment.create(name: 'wasdev1-snapshot',
+  url: 'http://bamboo:8085/deploy/viewEnvironment.action?id=26640388')
+
+cv_service.instance << create_instance(version: '4',
+  version_of_artifact: '4.0.0 [2013-11-05 18:26:00 EST]',
+  direct_url: 'http://ihswasdev/CommutedValueWS400/CommutedValueService',
+  mediation_url: 'http://indy:8889/gateway2MediationWeb/sca/gateway2Export_WS_SOAP11/cvws4')
+
+cv_service.instance << create_instance(version: '5',
+  version_of_artifact: '5.0.0 [2014-02-26 12:26:09 EST]',
+  direct_url: 'http://ihswasdev/CommutedValueWS500/CommutedValueService',
+  mediation_url: 'http://indy:8889/gateway2MediationWeb/sca/gateway2Export_WS_SOAP11/cvws5')
+
+cv_service.instance << create_instance(version: '6',
+  version_of_artifact: '6.0.0 [2014-04-25 11:47:39 EDT',
+  direct_url: 'http://ihswasdev/CommutedValueWS600/CommutedValueService',
+  mediation_url: 'http://indy:8889/gateway2MediationWeb/sca/gateway2Export_WS_SOAP11/cvws6')
+
+# Save all the Instances created
+cv_service.instance.each { |instance| instance.save }
+
+cv_service.save

--- a/test/fixtures/deployments.yml
+++ b/test/fixtures/deployments.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  description: MyString
+  url: MyString
+  service_id: 
+
+two:
+  name: MyString
+  description: MyString
+  url: MyString
+  service_id: 

--- a/test/fixtures/endpoints.yml
+++ b/test/fixtures/endpoints.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  description: MyString
+  endpoint_type: MyString
+  url: MyString
+  instance_id: 
+
+two:
+  name: MyString
+  description: MyString
+  endpoint_type: MyString
+  url: MyString
+  instance_id: 

--- a/test/fixtures/instances.yml
+++ b/test/fixtures/instances.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  version_of_artifact: MyString
+  description: MyString
+  service_id: 
+
+two:
+  name: MyString
+  version_of_artifact: MyString
+  description: MyString
+  service_id: 

--- a/test/fixtures/repositories.yml
+++ b/test/fixtures/repositories.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  description: MyString
+  url: MyString
+  service_id: 
+
+two:
+  description: MyString
+  url: MyString
+  service_id: 

--- a/test/fixtures/services.yml
+++ b/test/fixtures/services.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  group: MyString
+  jira: MyString
+  confluence: MyString
+
+two:
+  name: MyString
+  group: MyString
+  jira: MyString
+  confluence: MyString

--- a/test/models/deployment_test.rb
+++ b/test/models/deployment_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class DeploymentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/endpoint_test.rb
+++ b/test/models/endpoint_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class EndpointTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/instance_test.rb
+++ b/test/models/instance_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class InstanceTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class RepositoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/service_test.rb
+++ b/test/models/service_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ServiceTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Started defining the models as we outlined in #1 

Creates a DB seed representing the CV web service as it is today. Feel free to check out this branch and `rake db:migrate`.

Take a look at the commit details to see how the model was generated, I document it there.
