### PR TITLE
Active model serializer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,9 @@ gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0',          group: :doc
 
+# Custom serializers
+gem 'active_model_serializers'
+
 gem 'rspec-rails', group: [:development, :test]
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,8 @@ GEM
       activesupport (= 4.1.1)
       builder (~> 3.1)
       erubis (~> 2.7.0)
+    active_model_serializers (0.8.1)
+      activemodel (>= 3.0)
     activemodel (4.1.1)
       activesupport (= 4.1.1)
       builder (~> 3.1)
@@ -175,6 +177,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers
   coffee-rails (~> 4.0.0)
   compass-rails
   guard-rspec

--- a/app/serializers/instance_serializer.rb
+++ b/app/serializers/instance_serializer.rb
@@ -1,0 +1,5 @@
+class InstanceSerializer < ActiveModel::Serializer
+  attributes :id, :name, :description, :version_of_artifact
+
+  has_many :endpoints
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,13 @@ module Swift
 
     config.generators.stylesheets = false
     config.generators.javascripts = false
+
+    # Disable for all serializers (except ArraySerializer)
+    ActiveModel::Serializer.root = false
+
+    # Disable for ArraySerializer
+    ActiveModel::ArraySerializer.root = false
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.


### PR DESCRIPTION
Not sure if we want to merge this in yet, but these changes customize the JSON serialization to have Instances return Endpoints. So when you get a resource like `/services/1/instances/1`, you get:

```
{
    "description": null,
    "endpoints": [
        {
            "created_at": "2014-06-09T20:24:13.396Z",
            "description": "WESB mediation to version 4",
            "endpoint_type": "WESB mediation",
            "id": 2,
            "instance_id": 1,
            "name": "Development.WESB.commutedValueService4",
            "updated_at": "2014-06-09T20:24:13.410Z",
            "url": "http://indy:8889/gateway2MediationWeb/sca/gateway2Export_WS_SOAP11/cvws4"
        },
        {
            "created_at": "2014-06-09T20:24:13.389Z",
            "description": "Direct endpoint to version 4",
            "endpoint_type": "Direct",
            "id": 1,
            "instance_id": 1,
            "name": "commutedValueService4",
            "updated_at": "2014-06-09T20:24:13.408Z",
            "url": "http://ihswasdev/CommutedValueWS400/CommutedValueService"
        }
    ],
    "id": 1,
    "name": "Commuted Value Service 4",
    "version_of_artifact": "4.0.0 [2013-11-05 18:26:00 EST]"
}
```

So we can leave this branch up here to demonstrate how Active Model Serializer works.

/cc @melima @nasimoyz 
